### PR TITLE
Add response data to streaming errors

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -211,7 +211,27 @@ function EventSource (url, eventSourceInitDict) {
 
       // Handle HTTP errors
       if (res.statusCode !== 200) {
-        failed({ status: res.statusCode, message: res.statusMessage })
+        var chunks = []
+        var returnError = function () {
+          res.removeAllListeners('close')
+          res.removeAllListeners('end')
+          var contentType = res.headers ? res.headers['content-type'] : ''
+          var data = chunks.length > 0 ? Buffer.concat(chunks).toString() : ''
+          failed({
+            status: res.statusCode,
+            message: res.statusMessage,
+            response: data ? {
+              data: contentType === 'application/json' ? JSON.parse(data) : data,
+            } : undefined,
+          })
+        }
+        res.on('data', function (chunk) {
+          chunks.push(chunk)
+        })
+        req.on('error', returnError)
+        req.on('timeout', returnError)
+        res.on('close', returnError)
+        res.on('end', returnError)
         return
       }
 

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -221,6 +221,7 @@ function EventSource (url, eventSourceInitDict) {
             status: res.statusCode,
             message: res.statusMessage,
             response: data ? {
+              status: res.statusCode,
               data: contentType === 'application/json' ? JSON.parse(data) : data,
             } : undefined,
           })

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -217,12 +217,19 @@ function EventSource (url, eventSourceInitDict) {
           res.removeAllListeners('end')
           var contentType = res.headers ? res.headers['content-type'] : ''
           var data = chunks.length > 0 ? Buffer.concat(chunks).toString() : ''
+          if (data && contentType === 'application/json') {
+             try {
+               var jsonData = JSON.parse(data)
+               if (jsonData) data = jsonData
+             }
+             catch { /**/ }
+          }
           failed({
             status: res.statusCode,
             message: res.statusMessage,
             response: data ? {
               status: res.statusCode,
-              data: contentType === 'application/json' ? JSON.parse(data) : data,
+              data: data,
             } : undefined,
           })
         }


### PR DESCRIPTION
- Add in same format as axios: An `Error` with `response` property containing `data` that maybe object or string